### PR TITLE
Edit blog post on package manager chains

### DIFF
--- a/_data/package_manager_matrix.csv
+++ b/_data/package_manager_matrix.csv
@@ -283,13 +283,11 @@ pacman,uv,python-uv-build,https://repology.org/project/uv/versions,repology
 pacman,vcpkg,vcpkg,https://repology.org/project/vcpkg/versions,repology
 pacman,Yarn,yarn-berry,https://repology.org/project/yarn/versions,repology
 pdm,Conan,conan,https://pypi.org/project/conan/,ecosystems
-pdm,Conda,conda,https://pypi.org/project/conda/,ecosystems
 pdm,pdm,pdm,https://pypi.org/project/pdm/,ecosystems
 pdm,pip,pip,https://pypi.org/project/pip/,ecosystems
 pdm,Poetry,poetry,https://pypi.org/project/poetry/,ecosystems
 pdm,uv,uv,https://pypi.org/project/uv/,ecosystems
 pip,Conan,conan,https://pypi.org/project/conan/,ecosystems
-pip,Conda,conda,https://pypi.org/project/conda/,ecosystems
 pip,pdm,pdm,https://pypi.org/project/pdm/,ecosystems
 pip,pip,pip,https://pypi.org/project/pip/,ecosystems
 pip,Poetry,poetry,https://pypi.org/project/poetry/,ecosystems
@@ -301,7 +299,6 @@ pnpm,npm,npm,https://www.npmjs.com/package/npm,ecosystems
 pnpm,pnpm,pnpm,https://www.npmjs.com/package/pnpm,ecosystems
 pnpm,Yarn,yarn,https://www.npmjs.com/package/yarn,ecosystems
 Poetry,Conan,conan,https://pypi.org/project/conan/,ecosystems
-Poetry,Conda,conda,https://pypi.org/project/conda/,ecosystems
 Poetry,pdm,pdm,https://pypi.org/project/pdm/,ecosystems
 Poetry,pip,pip,https://pypi.org/project/pip/,ecosystems
 Poetry,Poetry,poetry,https://pypi.org/project/poetry/,ecosystems
@@ -329,7 +326,6 @@ Spack,Spack,spack,https://repology.org/project/spack/versions,repology
 Spack,Yarn,yarn,https://repology.org/project/yarn/versions,repology
 Stack,Cabal,cabal-install,https://hackage.haskell.org/package/cabal-install,manual
 uv,Conan,conan,https://pypi.org/project/conan/,ecosystems
-uv,Conda,conda,https://pypi.org/project/conda/,ecosystems
 uv,pdm,pdm,https://pypi.org/project/pdm/,ecosystems
 uv,pip,pip,https://pypi.org/project/pip/,ecosystems
 uv,Poetry,poetry,https://pypi.org/project/poetry/,ecosystems


### PR DESCRIPTION
Hello Andrew, I was reading https://nesbitt.io/2026/05/28/package-managers-that-package-package-managers.html and I really liked it! It got me curious and I looked closer at the package manager chain at the end of the post.

Conda is not installable from PyPI anymore. So I think it's fair to remove it as something that pip, uv, pdm and poetry can install.

That unfortunately breaks your chain... But I think we can somehow repair it by replacing conda with conan:

1. yay -S brew-git
1. brew install python@3
1. pip install poetry
1. poetry init -n && poetry add pdm
1. poetry run pdm init -n && poetry run pdm add uv
1. poetry run pdm run uv tool install conan
1. conan install npm
1. npm install -g yarn
1. yarn global add pnpm
1. pnpm add -g bun
1. bun add -g elm

or something like that. Thoughts?

We could likely extend the chain by one by injecting spack in there, maybe but I'm not yet sure how. And just for the sake of it, we can extend it by one more by making the first instruction be `pacman -S yay`, though, I'm not sure if yay can be called a package manager...

Another thought I had was to use rattler as another hop instead of conda. Rattler doesn't really have a public facing CLI, but it's the engine behind pixi and rattler is available on PyPI.