### PR TITLE
conda-forge packages bun & pnpm

### DIFF
--- a/_data/package_manager_matrix.csv
+++ b/_data/package_manager_matrix.csv
@@ -88,6 +88,7 @@ Conda,npm,nodejs,https://anaconda.org/conda-forge/nodejs,manual
 Conda,opam,opam,https://anaconda.org/conda-forge/opam,ecosystems
 Conda,pdm,pdm,https://anaconda.org/anaconda/pdm,ecosystems
 Conda,pip,pip,https://anaconda.org/conda-forge/pip,ecosystems
+Conda,pnpm,pnpm,https://anaconda.org/anaconda/pnpm,ecosystems
 Conda,Poetry,poetry,https://anaconda.org/conda-forge/poetry,ecosystems
 Conda,Stack,stack,https://anaconda.org/conda-forge/stack,ecosystems
 Conda,uv,uv-build,https://anaconda.org/anaconda/uv-build,ecosystems

--- a/_data/package_manager_matrix.csv
+++ b/_data/package_manager_matrix.csv
@@ -70,13 +70,14 @@ Cargo,pnpm,,https://crates.io/crates/pnpm-registry,squat
 Cargo,uv,uv,https://crates.io/crates/uv/,ecosystems
 Composer,Composer,composer/composer,https://packagist.org/packages/composer/composer#,ecosystems
 Conan,npm,nodejs,https://conan.io/center/recipes/nodejs,manual
+Conda,Bun,bun,https://anaconda.org/anaconda/bun,ecosystems
 Conda,Cabal,cabal,https://anaconda.org/conda-forge/cabal,ecosystems
 Conda,Cargo,rust,https://anaconda.org/anaconda/rust,ecosystems
 Conda,Conan,conan,https://anaconda.org/conda-forge/conan,ecosystems
 Conda,Conda,conda,https://anaconda.org/anaconda/conda,ecosystems
 Conda,dub,dub,https://anaconda.org/conda-forge/dub,ecosystems
 Conda,Elm,elm,https://anaconda.org/conda-forge/elm,ecosystems
-Conda,Go,go-cgo_win-64,https://anaconda.org/anaconda/go-cgo_win-64,ecosystems
+Conda,Go,go,https://anaconda.org/anaconda/go,ecosystems
 Conda,Gradle,gradle,https://anaconda.org/conda-forge/gradle,ecosystems
 Conda,Helm,kubernetes-helm,https://anaconda.org/conda-forge/kubernetes-helm,ecosystems
 Conda,Julia,julia,https://anaconda.org/conda-forge/julia,ecosystems


### PR DESCRIPTION
Hey, fun [article](https://nesbitt.io/2026/05/28/package-managers-that-package-package-managers.html)! :)

Just thought I'd point out that conda-forge supports [`bun`](https://github.com/conda-forge/bun-feedstock) since a few months (it took a while for `$REASONS`); [`pnpm`](https://github.com/conda-forge/pnpm-feedstock) has been there for a while already.

Also, you can point to the platform-independent metapackage for [`go`](https://conda-metadata-app.streamlit.app/?q=conda-forge%2Fwin-64%2Fgo-1.26.3-h59133dd_0.conda), rather than the windows-specific `go-cgo_win-64`. Strictly speaking that's missing the "activation" bits from https://github.com/conda-forge/go-activation-feedstock, but all things considered, I think that's still less bad than putting in a windows-only package.